### PR TITLE
fix: avoid fluent test race in CI

### DIFF
--- a/i18n/tests/fluent.rs
+++ b/i18n/tests/fluent.rs
@@ -332,7 +332,9 @@ fn test_tr_macro_with_multiple_args() {
 
 #[test]
 fn test_languages_contains_loaded() {
-  load_no_iso("hu-HU", "k = v");
+  // This test only checks registry enumeration, so keep it parallel-safe by
+  // avoiding the global `use_isolating` toggle used by `load_no_iso`.
+  load("hu-HU", "k = v");
   assert!(egui_i18n::languages().contains(&"hu-HU".to_string()));
 }
 


### PR DESCRIPTION
## Summary
- stop the fluent `languages()` integration test from toggling global isolating state outside the serialized section
- keep the test parallel-safe by loading translations with `load(...)` instead of `load_no_iso(...)`
- document the race so the CI failure mode is obvious from the test itself

## Validation
- `for i in $(seq 1 50); do cargo test -q -p egui-i18n --features fluent --test fluent || exit 1; done`
- `cargo clippy -p egui-i18n --features classic -- -D warnings`
- `cargo test -p egui-i18n --features classic --test classic`
- `cargo clippy -p egui-i18n --features fluent -- -D warnings`
- `cargo test -p egui-i18n --features fluent --test fluent`
- `cargo clippy -p egui-i18n-cli -- -D warnings`
- `cargo check -p egui-i18n-cli`
- `cargo clippy -p egui-i18n-example-classic -- -D warnings`
- `cargo check -p egui-i18n-example-classic`
- `cargo clippy -p egui-i18n-example-fluent -- -D warnings`
- `cargo check -p egui-i18n-example-fluent`

## Issue
- OHH-7
